### PR TITLE
new quick surface dist impl

### DIFF
--- a/src/org/opensha/sha/faultSurface/QuadSurface.java
+++ b/src/org/opensha/sha/faultSurface/QuadSurface.java
@@ -585,6 +585,17 @@ public class QuadSurface implements RuptureSurface, CacheEnabledSurface {
 	}
 	
 	@Override
+	public double getQuickDistance(Location siteLoc) {
+		return cache.getQuickDistance(siteLoc);
+	}	
+
+	@Override
+	public double calcQuickDistance(Location siteLoc) {
+		// just use DistanceRup
+		return cache.getSurfaceDistances(siteLoc).getDistanceRup();
+	}
+	
+	@Override
 	public synchronized double calcDistanceX(Location siteLoc) {
 		// this is Peter's implementation, but it doesn't perform as well in tests
 //		if (1d < 2d) {

--- a/src/org/opensha/sha/simulators/TriangularElementSurface.java
+++ b/src/org/opensha/sha/simulators/TriangularElementSurface.java
@@ -137,6 +137,11 @@ class TriangularElementSurface implements RuptureSurface {
 	}
 
 	@Override
+	public double getQuickDistance(Location siteLoc) {
+		return getDistanceRup(siteLoc);
+	}
+
+	@Override
 	public double getDistanceJB(Location siteLoc) {
 		throw new UnsupportedOperationException("Not yet implemented");
 	}


### PR DESCRIPTION
I discovered that UCERF3 hazard curve calculations were spending most of their time performing the source.getMinDistance(loc) method, which bypassed all of the distance calculation caching. That distance was calculated to the corners of each individual subsection.

I added a new RuptureSurface.getQuickDistance(Location) method to RuptureSurface address this bottleneck, and also implemented a cache (see CacheEnabledSurface). Each surface can implement the quick distance in whichever way is most efficient, and the implementation for gridded surfaces is the same as before.

In core, I changed the getMinDistance(loc) method to use this method (and it's underlying cache), which sped up fault-source-only UCERF3 hazard curve calculation by a factor of ~8x (from 8 seconds to 1 second).